### PR TITLE
fix: added check when vesting staked escrow

### DIFF
--- a/contracts/RewardEscrow.sol
+++ b/contracts/RewardEscrow.sol
@@ -254,7 +254,7 @@ contract RewardEscrow is Owned, IRewardEscrow {
      * @param _amount The amount of escrowed KWENTA to be staked.
      */
     function stakeEscrow(uint256 _amount) override external {
-        require(_amount + stakingRewards.escrowedBalanceOf(msg.sender) <= totalEscrowedAccountBalance[msg.sender]);
+        require(_amount + stakingRewards.escrowedBalanceOf(msg.sender) <= totalEscrowedAccountBalance[msg.sender], "Insufficient unstaked escrow");
         stakingRewards.stakeEscrow(msg.sender, _amount);
     }
 


### PR DESCRIPTION
Currently you can vest actively "staked" escrow because the tokens still exist in the escrow contract. This adds a check that automatically unstakes escrowed Kwenta if `vesting amount > unstaked escrow`.