### PR TITLE
fix: removed the code handling the 0 case for root_any

### DIFF
--- a/contracts/libraries/ExponentLib.sol
+++ b/contracts/libraries/ExponentLib.sol
@@ -35,11 +35,7 @@ library ExponentLib {
     }
 
     function root_any(FixidityLib.Fixidity storage fixidity, int256 a, int256 b) public view returns (int256) {
-        if(a == 0) {
-            return 0;
-        } else {
-            return power_any(fixidity, a, fixidity.reciprocal(b));
-        }
+        return power_any(fixidity, a, fixidity.reciprocal(b));
     }
 
     function root_n(FixidityLib.Fixidity storage fixidity, int256 a, uint256 n) public view returns (int256) {


### PR DESCRIPTION
Removed the check within root_any in Fixidity as the reward score is finally calculated with power_any and the 0 case is handled in StakingRewards 