### PR TITLE
Refactor: isMintable and setMinterReward

### DIFF
--- a/contracts/SupplySchedule.sol
+++ b/contracts/SupplySchedule.sol
@@ -184,19 +184,6 @@ contract SupplySchedule is Owned, ISupplySchedule {
     }
 
     /**
-     * @notice Sets the reward amount of KWENTA for the caller of the public
-     * function Kwenta.mint().
-     * This incentivises anyone to mint the inflationary supply and the mintr
-     * Reward will be deducted from the inflationary supply and sent to the caller.
-     * @param amount the amount of KWENTA to reward the minter.
-     * */
-    function setMinterReward(uint amount) external onlyOwner {
-        require(amount <= MAX_MINTER_REWARD, "Reward cannot exceed max minter reward");
-        minterReward = amount;
-        emit MinterRewardUpdated(minterReward);
-    }
-
-    /**
      * @notice Mints new inflationary supply weekly
      * New KWENTA is distributed between the minter, treasury, and StakingRewards contract
      * */
@@ -230,6 +217,19 @@ contract SupplySchedule is Owned, ISupplySchedule {
         require(address(_kwenta) != address(0), "Address cannot be 0");
         kwenta = _kwenta;
         emit KwentaUpdated(address(kwenta));
+    }
+
+    /**
+     * @notice Sets the reward amount of KWENTA for the caller of the public
+     * function Kwenta.mint().
+     * This incentivises anyone to mint the inflationary supply and the mintr
+     * Reward will be deducted from the inflationary supply and sent to the caller.
+     * @param amount the amount of KWENTA to reward the minter.
+     * */
+    function setMinterReward(uint amount) external onlyOwner {
+        require(amount <= MAX_MINTER_REWARD, "Reward cannot exceed max minter reward");
+        minterReward = amount;
+        emit MinterRewardUpdated(minterReward);
     }
 
     function setTreasuryDiversion(uint _treasuryDiversion) override public onlyOwner {


### PR DESCRIPTION
Refactor isMintable for cleanliness and move `setMinterReward()` to proper file location

## Description
* Remove unnecessary code for isMintable
* Move `setMinterReward()` to Setters section

## Related issue
[56](https://github.com/Kwenta/token/issues/56)
[57](https://github.com/Kwenta/token/issues/57)

## Motivation and Context
Refactoring (small changes)