### PR TITLE
Integration test bug(s)

### DIFF
--- a/test/local/integration/stake.behavior.ts
+++ b/test/local/integration/stake.behavior.ts
@@ -219,7 +219,8 @@ describe('Stake', () => {
 			await rewardEscrow.connect(addr1).stakeEscrow(TEST_VALUE);
 			await rewardEscrow.connect(addr2).stakeEscrow(SMALLER_TEST_VALUE);
 
-			// check escrow balance(s) and expect balance of staked escrow to be > 0
+			// check escrow balance(s) and expect balance of 
+			// staked escrow to be what was staked above
 			expect(
 				await stakingRewardsProxy.escrowedBalanceOf(addr1.address)
 			).to.equal(TEST_VALUE);


### PR DESCRIPTION
Fixes two bugs:
1. Investigate integration tests that failed during the audit when gas reporting was disabled
2. Seconds in week value was corrected

## Description
* Investigate `hardhat-gas-reporter`
* Correct `SECONDS_IN_WEEK`

## Related issue(s)
Closes [Failing integration tests #96](https://github.com/Kwenta/token/issues/96)
Closes [Incorrect value in integration tests #97](https://github.com/Kwenta/token/issues/97)

## Motivation and Context
https://gist.github.com/bernard-wagner/fe66813e1d39c79193bc24bc2081be6a#511-failing-integration-tests
https://gist.github.com/bernard-wagner/fe66813e1d39c79193bc24bc2081be6a#522-incorrect-value-in-integration-tests
