### PR TITLE
Refactor SafeDecimalMath: Remove unused functions

### DIFF
--- a/contracts/libraries/SafeDecimalMath.sol
+++ b/contracts/libraries/SafeDecimalMath.sol
@@ -3,29 +3,29 @@ pragma solidity ^0.8.0;
 
 // https://docs.synthetix.io/contracts/source/libraries/safedecimalmath
 library SafeDecimalMath {
-
     /* Number of decimal places in the representations. */
     uint8 public constant decimals = 18;
     uint8 public constant highPrecisionDecimals = 27;
 
     /* The number representing 1.0. */
-    uint public constant UNIT = 10**uint(decimals);
+    uint256 public constant UNIT = 10**uint256(decimals);
 
     /* The number representing 1.0 for higher fidelity numbers. */
-    uint public constant PRECISE_UNIT = 10**uint(highPrecisionDecimals);
-    uint private constant UNIT_TO_HIGH_PRECISION_CONVERSION_FACTOR = 10**uint(highPrecisionDecimals - decimals);
+    uint256 public constant PRECISE_UNIT = 10**uint256(highPrecisionDecimals);
+    uint256 private constant UNIT_TO_HIGH_PRECISION_CONVERSION_FACTOR =
+        10**uint256(highPrecisionDecimals - decimals);
 
     /**
      * @return Provides an interface to UNIT.
      */
-    function unit() external pure returns (uint) {
+    function unit() external pure returns (uint256) {
         return UNIT;
     }
 
     /**
      * @return Provides an interface to PRECISE_UNIT.
      */
-    function preciseUnit() external pure returns (uint) {
+    function preciseUnit() external pure returns (uint256) {
         return PRECISE_UNIT;
     }
 
@@ -38,68 +38,13 @@ library SafeDecimalMath {
      * the internal division always rounds down. This helps save on gas. Rounding
      * is more expensive on gas.
      */
-    function multiplyDecimal(uint x, uint y) internal pure returns (uint) {
+    function multiplyDecimal(uint256 x, uint256 y)
+        internal
+        pure
+        returns (uint256)
+    {
         /* Divide by UNIT to remove the extra factor introduced by the product. */
-        return x * y / UNIT;
-    }
-
-    /**
-     * @return The result of safely multiplying x and y, interpreting the operands
-     * as fixed-point decimals of the specified precision unit.
-     *
-     * @dev The operands should be in the form of a the specified unit factor which will be
-     * divided out after the product of x and y is evaluated, so that product must be
-     * less than 2**256.
-     *
-     * Unlike multiplyDecimal, this function rounds the result to the nearest increment.
-     * Rounding is useful when you need to retain fidelity for small decimal numbers
-     * (eg. small fractions or percentages).
-     */
-    function _multiplyDecimalRound(
-        uint x,
-        uint y,
-        uint precisionUnit
-    ) private pure returns (uint) {
-        /* Divide by UNIT to remove the extra factor introduced by the product. */
-        uint quotientTimesTen = x * y / (precisionUnit / 10);
-
-        if (quotientTimesTen % 10 >= 5) {
-            quotientTimesTen += 10;
-        }
-
-        return quotientTimesTen / 10;
-    }
-
-    /**
-     * @return The result of safely multiplying x and y, interpreting the operands
-     * as fixed-point decimals of a precise unit.
-     *
-     * @dev The operands should be in the precise unit factor which will be
-     * divided out after the product of x and y is evaluated, so that product must be
-     * less than 2**256.
-     *
-     * Unlike multiplyDecimal, this function rounds the result to the nearest increment.
-     * Rounding is useful when you need to retain fidelity for small decimal numbers
-     * (eg. small fractions or percentages).
-     */
-    function multiplyDecimalRoundPrecise(uint x, uint y) internal pure returns (uint) {
-        return _multiplyDecimalRound(x, y, PRECISE_UNIT);
-    }
-
-    /**
-     * @return The result of safely multiplying x and y, interpreting the operands
-     * as fixed-point decimals of a standard unit.
-     *
-     * @dev The operands should be in the standard unit factor which will be
-     * divided out after the product of x and y is evaluated, so that product must be
-     * less than 2**256.
-     *
-     * Unlike multiplyDecimal, this function rounds the result to the nearest increment.
-     * Rounding is useful when you need to retain fidelity for small decimal numbers
-     * (eg. small fractions or percentages).
-     */
-    function multiplyDecimalRound(uint x, uint y) internal pure returns (uint) {
-        return _multiplyDecimalRound(x, y, UNIT);
+        return (x * y) / UNIT;
     }
 
     /**
@@ -111,69 +56,36 @@ library SafeDecimalMath {
      * this is an integer division, the result is always rounded down.
      * This helps save on gas. Rounding is more expensive on gas.
      */
-    function divideDecimal(uint x, uint y) internal pure returns (uint) {
+    function divideDecimal(uint256 x, uint256 y)
+        internal
+        pure
+        returns (uint256)
+    {
         /* Reintroduce the UNIT factor that will be divided out by y. */
-        return x * UNIT / y;
-    }
-
-    /**
-     * @return The result of safely dividing x and y. The return value is as a rounded
-     * decimal in the precision unit specified in the parameter.
-     *
-     * @dev y is divided after the product of x and the specified precision unit
-     * is evaluated, so the product of x and the specified precision unit must
-     * be less than 2**256. The result is rounded to the nearest increment.
-     */
-    function _divideDecimalRound(
-        uint x,
-        uint y,
-        uint precisionUnit
-    ) private pure returns (uint) {
-        uint resultTimesTen = x * precisionUnit * 10 / y;
-
-        if (resultTimesTen % 10 >= 5) {
-            resultTimesTen += 10;
-        }
-
-        return resultTimesTen / 10;
-    }
-
-    /**
-     * @return The result of safely dividing x and y. The return value is as a rounded
-     * standard precision decimal.
-     *
-     * @dev y is divided after the product of x and the standard precision unit
-     * is evaluated, so the product of x and the standard precision unit must
-     * be less than 2**256. The result is rounded to the nearest increment.
-     */
-    function divideDecimalRound(uint x, uint y) internal pure returns (uint) {
-        return _divideDecimalRound(x, y, UNIT);
-    }
-
-    /**
-     * @return The result of safely dividing x and y. The return value is as a rounded
-     * high precision decimal.
-     *
-     * @dev y is divided after the product of x and the high precision unit
-     * is evaluated, so the product of x and the high precision unit must
-     * be less than 2**256. The result is rounded to the nearest increment.
-     */
-    function divideDecimalRoundPrecise(uint x, uint y) internal pure returns (uint) {
-        return _divideDecimalRound(x, y, PRECISE_UNIT);
+        return (x * UNIT) / y;
     }
 
     /**
      * @dev Convert a standard decimal representation to a high precision one.
      */
-    function decimalToPreciseDecimal(uint i) internal pure returns (uint) {
+    function decimalToPreciseDecimal(uint256 i)
+        internal
+        pure
+        returns (uint256)
+    {
         return i * UNIT_TO_HIGH_PRECISION_CONVERSION_FACTOR;
     }
 
     /**
      * @dev Convert a high precision decimal to a standard decimal representation.
      */
-    function preciseDecimalToDecimal(uint i) internal pure returns (uint) {
-        uint quotientTimesTen = i / (UNIT_TO_HIGH_PRECISION_CONVERSION_FACTOR / 10);
+    function preciseDecimalToDecimal(uint256 i)
+        internal
+        pure
+        returns (uint256)
+    {
+        uint256 quotientTimesTen = i /
+            (UNIT_TO_HIGH_PRECISION_CONVERSION_FACTOR / 10);
 
         if (quotientTimesTen % 10 >= 5) {
             quotientTimesTen += 10;
@@ -183,7 +95,7 @@ library SafeDecimalMath {
     }
 
     // Computes `a - b`, setting the value to 0 if b > a.
-    function floorsub(uint a, uint b) internal pure returns (uint) {
+    function floorsub(uint256 a, uint256 b) internal pure returns (uint256) {
         return b >= a ? 0 : a - b;
     }
 }


### PR DESCRIPTION
Remove unused multiplication and division functions in SafeDecimalMath.sol