### PR TITLE
proposed fix to sync periodFinish with epoch ends

### DIFF
--- a/contracts/StakingRewards.sol
+++ b/contracts/StakingRewards.sol
@@ -534,20 +534,17 @@ contract StakingRewards is IStakingRewards, ReentrancyGuardUpgradeable, Pausable
      * @param reward, total amount to distribute
      */  
     function setRewards(uint256 reward) override external onlySupplySchedule updateRewards(address(0)) {
-        if (block.timestamp >= periodFinish) {
-            rewardRate = reward / WEEK;
-        } else {
-            uint256 remaining = periodFinish - block.timestamp;
-            // @notice this is previous rewardRate
-            uint256 leftover = remaining * rewardRate;
-            rewardRate = reward + (leftover / WEEK);
+        if (periodFinish < currentEpoch) {
+            periodFinish = currentEpoch;
         }
+        uint timeElapsedFromExpectedPeriodStart = (block.timestamp - periodFinish) % WEEK;
+        rewardRate = reward / (WEEK - timeElapsedFromExpectedPeriodStart);
 
         rewardRateStaking = rewardRate * percentageStaking / MAX_BPS;
         rewardRateTrading = rewardRate * percentageTrading / MAX_BPS;
 
         lastUpdateTime = block.timestamp;
-        periodFinish = block.timestamp + WEEK;
+        periodFinish = periodFinish + WEEK;
         emit RewardAdded(reward);
     }
 


### PR DESCRIPTION
This change makes it so that `periodFinish` will always be in sync with the trading epochs. 
https://github.com/Kwenta/token/blob/498fda17a285a2a8422dddc182de8d31a48785d1/contracts/StakingRewards.sol#L547

Now we don't have to worry about "keeper drift", but we do have to make sure rewards are not lost if we `setRewards` in the middle of a period. This is fixed with: 
https://github.com/Kwenta/token/blob/498fda17a285a2a8422dddc182de8d31a48785d1/contracts/StakingRewards.sol#L540-L541