### PR TITLE
refactor: change variable to better match deploy script logic

### DIFF
--- a/contracts/Kwenta.sol
+++ b/contracts/Kwenta.sol
@@ -25,10 +25,9 @@ contract Kwenta is ERC20, Owned, IKwenta {
         string memory symbol,
         uint256 _initialSupply,
         address _owner,
-        address _treasuryDAO
+        address _initialHolder
     ) ERC20(name, symbol) Owned(_owner) {
-        // Provide treasury with 100% of the initial supply
-        _mint(_treasuryDAO, _initialSupply);
+        _mint(_initialHolder, _initialSupply);
     }
 
     // Mints inflationary supply


### PR DESCRIPTION
Updating constructor variable name because initial supply goes to deployer first before going to the treasury

https://github.com/Kwenta/token/blob/31484869481dd5a849c7c8f176c538d7c24412b6/scripts/deploy.ts#L151-L159