### PR TITLE
Switch to two step ownable

### DIFF
--- a/contracts/RewardEscrowV2.sol
+++ b/contracts/RewardEscrowV2.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.19;
 import {IRewardEscrowV2} from "./interfaces/IRewardEscrowV2.sol";
 import {ERC721EnumerableUpgradeable} from
     "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {PausableUpgradeable} from
     "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
@@ -20,7 +20,7 @@ import {IStakingRewardsV2} from "./interfaces/IStakingRewardsV2.sol";
 contract RewardEscrowV2 is
     IRewardEscrowV2,
     ERC721EnumerableUpgradeable,
-    OwnableUpgradeable,
+    Ownable2StepUpgradeable,
     PausableUpgradeable,
     UUPSUpgradeable
 {

--- a/contracts/RewardEscrowV2.sol
+++ b/contracts/RewardEscrowV2.sol
@@ -106,7 +106,7 @@ contract RewardEscrowV2 is
 
         // Initialize inherited contracts
         __ERC721_init("Kwenta Reward Escrow", "KRE");
-        __Ownable_init();
+        __Ownable2Step_init();
         __Pausable_init();
         __UUPSUpgradeable_init();
 

--- a/contracts/StakingRewardsV2.sol
+++ b/contracts/StakingRewardsV2.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {PausableUpgradeable} from
     "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {IKwenta} from "./interfaces/IKwenta.sol";
 import {IStakingRewardsV2} from "./interfaces/IStakingRewardsV2.sol";
@@ -18,7 +18,7 @@ import {IRewardEscrowV2} from "./interfaces/IRewardEscrowV2.sol";
 /// @notice Updated version of Synthetix's StakingRewards with new features specific to Kwenta
 contract StakingRewardsV2 is
     IStakingRewardsV2,
-    OwnableUpgradeable,
+    Ownable2StepUpgradeable,
     PausableUpgradeable,
     UUPSUpgradeable
 {

--- a/contracts/StakingRewardsV2.sol
+++ b/contracts/StakingRewardsV2.sol
@@ -163,7 +163,7 @@ contract StakingRewardsV2 is
         if (_contractOwner == address(0)) revert ZeroAddress();
 
         // initialize owner
-        __Ownable_init();
+        __Ownable2Step_init();
         __Pausable_init();
         __UUPSUpgradeable_init();
 

--- a/test/foundry/unit/RewardEscrowV2/RewardEscrowV2.t.sol
+++ b/test/foundry/unit/RewardEscrowV2/RewardEscrowV2.t.sol
@@ -49,6 +49,60 @@ contract RewardEscrowV2Tests is DefaultStakingV2Setup {
     }
 
     /*//////////////////////////////////////////////////////////////
+                            OWNERSHIP TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Only_Owner_Can_Set_Staking_TreasuryDAO() public {
+        vm.prank(user1);
+        vm.expectRevert("Ownable: caller is not the owner");
+        rewardEscrowV2.setTreasuryDAO(user1);
+    }
+
+    function test_Only_Owner_Can_Renounce_Ownership() public {
+        vm.prank(user1);
+        vm.expectRevert("Ownable: caller is not the owner");
+        stakingRewardsV2.renounceOwnership();
+    }
+
+    function test_Only_Owner_Can_Transfer_Ownership() public {
+        vm.prank(user1);
+        vm.expectRevert("Ownable: caller is not the owner");
+        stakingRewardsV2.transferOwnership(user2);
+    }
+
+    function test_Renounce_Ownership() public {
+        stakingRewardsV2.renounceOwnership();
+        assertEq(stakingRewardsV2.owner(), address(0));
+    }
+
+    function test_Transfer_Ownership() public {
+        // check ownership
+        assertEq(rewardEscrowV2.owner(), address(this));
+
+        // transfer ownership
+        rewardEscrowV2.transferOwnership(user1);
+
+        // accept ownership
+        vm.prank(user1);
+        rewardEscrowV2.acceptOwnership();
+
+        // check ownership
+        assertEq(rewardEscrowV2.owner(), address(user1));
+        vm.expectRevert("Ownable: caller is not the owner");
+        rewardEscrowV2.transferOwnership(address(this));
+
+        // transfer ownership
+        vm.prank(user1);
+        rewardEscrowV2.transferOwnership(address(this));
+
+        // accept ownership
+        rewardEscrowV2.acceptOwnership();
+
+        // check ownership
+        assertEq(rewardEscrowV2.owner(), address(this));
+    }
+
+    /*//////////////////////////////////////////////////////////////
                         When No Escrow Entries
     //////////////////////////////////////////////////////////////*/
 

--- a/test/foundry/unit/StakingRewardsV2/StakingRewardsV2.t.sol
+++ b/test/foundry/unit/StakingRewardsV2/StakingRewardsV2.t.sol
@@ -124,6 +124,10 @@ contract StakingRewardsV2Test is DefaultStakingV2Setup {
         // transfer ownership
         stakingRewardsV2.transferOwnership(user1);
 
+        // accept ownership
+        vm.prank(user1);
+        stakingRewardsV2.acceptOwnership();
+
         // check ownership
         assertEq(stakingRewardsV2.owner(), address(user1));
         vm.expectRevert("Ownable: caller is not the owner");
@@ -132,6 +136,9 @@ contract StakingRewardsV2Test is DefaultStakingV2Setup {
         // transfer ownership
         vm.prank(user1);
         stakingRewardsV2.transferOwnership(address(this));
+
+        // accept ownership
+        stakingRewardsV2.acceptOwnership();
 
         // check ownership
         assertEq(stakingRewardsV2.owner(), address(this));

--- a/test/foundry/utils/setup/StakingV2Setup.t.sol
+++ b/test/foundry/utils/setup/StakingV2Setup.t.sol
@@ -74,6 +74,11 @@ contract StakingV2Setup is StakingV1Setup {
         vm.expectRevert(IRewardEscrowV2.ZeroAddress.selector);
         rewardEscrowV2.setStakingRewards(address(0));
 
+        // check staking rewards can only be set by owner
+        vm.prank(user1);
+        vm.expectRevert("Ownable: caller is not the owner");
+        rewardEscrowV2.setStakingRewards(address(stakingRewardsV2));
+
         // Setup StakingV2
         vm.expectEmit(true, true, true, true);
         emit StakingRewardsSet(address(stakingRewardsV2));


### PR DESCRIPTION
Over the weekend I was reading about security best practices and I came across `Ownable2StepUpgradeable`.

I think this is much more secure and we should use this instead of `OwnableUpgradeable`, as it makes it impossible to transfer ownership to the wrong address.

It would be difficult to make this upgrade after deploying.