### PR TITLE
Dual rewards audit fixes

### DIFF
--- a/test/foundry/unit/StakingRewardsV2/StakingRewardsV2.t.sol
+++ b/test/foundry/unit/StakingRewardsV2/StakingRewardsV2.t.sol
@@ -388,13 +388,7 @@ contract StakingRewardsV2Test is DefaultStakingV2Setup {
 
     function test_Can_Recover_Non_Staking_Token() public {
         // create mockToken
-        IERC20 mockToken = new Kwenta(
-            "Mock",
-            "MOCK",
-            INITIAL_SUPPLY,
-            address(this),
-            treasury
-        );
+        IERC20 mockToken = new Kwenta("Mock", "MOCK", INITIAL_SUPPLY, address(this), treasury);
 
         // transfer in non staking tokens
         vm.prank(treasury);
@@ -474,7 +468,7 @@ contract StakingRewardsV2Test is DefaultStakingV2Setup {
         vm.warp(block.timestamp + 1 weeks);
 
         // check reward per token updated
-        assertEq(stakingRewardsV2.rewardPerTokenUSDC(), 1 ether);
+        assertEq(stakingRewardsV2.rewardPerTokenUSDC(), 1 ether * PRECISION);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -722,7 +716,7 @@ contract StakingRewardsV2Test is DefaultStakingV2Setup {
 
         // configure reward rate
         vm.prank(address(rewardsNotifier));
-        stakingRewardsV2.notifyRewardAmount(0 , TEST_VALUE);
+        stakingRewardsV2.notifyRewardAmount(0, TEST_VALUE);
 
         // fast forward 2 weeks
         vm.warp(block.timestamp + 2 weeks);
@@ -761,7 +755,9 @@ contract StakingRewardsV2Test is DefaultStakingV2Setup {
         assertEq(finalRewardRate / 2, initialRewardRate);
     }
 
-    function test_rewardRateUSDC_Should_Increase_If_New_Rewards_Come_Before_Duration_Ends() public {
+    function test_rewardRateUSDC_Should_Increase_If_New_Rewards_Come_Before_Duration_Ends()
+        public
+    {
         fundAndApproveAccountV2(address(this), 1 weeks);
 
         uint256 totalToDistribute = 5 ether;

--- a/test/foundry/utils/Constants.t.sol
+++ b/test/foundry/utils/Constants.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.19;
 
 uint256 constant INITIAL_SUPPLY = 313_373 ether;
 uint256 constant TEST_VALUE = 1 ether;
+uint256 constant PRECISION = 1e12;
 
 /*//////////////////////////////////////////////////////////////
                             FORK CONSTANTS
@@ -33,8 +34,8 @@ address constant OPTIMISM_STAKING_REWARDS_V2 = 0x61294940CE7cD1BDA10e349adC5B538
 address constant OPTIMISM_REWARD_ESCROW_V2 = 0xb2a20fCdc506a685122847b21E34536359E94C56;
 address constant OPTIMISM_ESCROW_MIGRATOR = 0xC9aF789Ae606F69cF8Ed073A04eC92f2354b027d;
 address constant OPTIMISM_STAKING_REWARDS_NOTIFIER = 0x03f6dC6e616AB3a367a1F2C26B8Bc146f632b451;
-uint256 constant OPTIMISM_STAKING_V2_FIRST_REWADRS_EMISSION_BLOCK = 109865536;
-uint256 constant OPTIMISM_STAKING_V2_FIRST_REWADRS_EMISSION_TIMESTAMP = 1695329849;
+uint256 constant OPTIMISM_STAKING_V2_FIRST_REWADRS_EMISSION_BLOCK = 109_865_536;
+uint256 constant OPTIMISM_STAKING_V2_FIRST_REWADRS_EMISSION_TIMESTAMP = 1_695_329_849;
 
 /*//////////////////////////////////////////////////////////////
                         GOERLI ADDRESSES


### PR DESCRIPTION
This pull request addresses feedback from recent audit reports by implementing a precision factor adjustment for USDC amounts.

## Description
* Add a `PRECISION` factor of `1e12` to the `_rewardUsdc` in the `notifyRewardAmount` function in order to to convert the USDC rewards to an 18-decimal value
* Scale down the usdc reward amount back to 6 decimals when calling `getReward`